### PR TITLE
CSS: Fix vertical cell alignment in tables

### DIFF
--- a/production/dwarf/stylesheets/application.css
+++ b/production/dwarf/stylesheets/application.css
@@ -1851,7 +1851,7 @@ table.list {
     text-align: left; }
   table.list tr td {
     font-size: 13px;
-    vertical-align: middle;
+    vertical-align: top;
     text-align: left; }
   table.list thead th {
     border: none;


### PR DESCRIPTION
This ensures that cells share a top alignment within a given table, fixing #21